### PR TITLE
Fix version typo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ x-init-ollama: &init-ollama
   command:
     - "-c"
     - "sleep 3; OLLAMA_HOST=ollama:11434 ollama pull qwen2.5:7b-instruct-q4_K_M; OLLAMA_HOST=ollama:11434 ollama pull nomic-embed-text"
-    # For a larger context length verison of the model, run these commands:
+    # For a larger context length version of the model, run these commands:
     # echo "FROM qwen2.5:7b-instruct-q4_K_M\n\nPARAMETER num_ctx 8096" > Modelfile
     # ollama create qwen2.5:7b-8k -f ./Modelfile
     # Change the name of the LLM and num_ctx as you see fit.


### PR DESCRIPTION
## Summary
- fix a small typo in docker-compose.yml comment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684166473660832488b5e62f95e470b2