### PR TITLE
Add async pipe test

### DIFF
--- a/tests/test_n8n_pipe.py
+++ b/tests/test_n8n_pipe.py
@@ -1,6 +1,6 @@
 import pytest
 
-from n8n_pipe import extract_event_info
+from n8n_pipe import extract_event_info, Pipe
 
 
 def make_emitter(info):
@@ -14,3 +14,20 @@ def test_extract_event_info_closure():
     captured = {"chat_id": "123", "message_id": "xyz"}
     emitter = make_emitter(captured)
     assert extract_event_info(emitter) == ("123", "xyz")
+
+
+@pytest.mark.asyncio
+async def test_pipe_no_messages_adds_assistant_reply():
+    pipe = Pipe()
+    events = []
+
+    async def dummy_emitter(event):
+        events.append(event)
+
+    body = {}
+    result = await pipe.pipe(body, __event_emitter__=dummy_emitter)
+
+    assert result == "No messages found in the request body"
+    assert body["messages"] == [
+        {"role": "assistant", "content": "No messages found in the request body"}
+    ]


### PR DESCRIPTION
## Summary
- expand test to cover Pipe.pipe

## Testing
- `python -m pytest -q` *(fails: test_pipe_no_messages_adds_assistant_reply)*

------
https://chatgpt.com/codex/tasks/task_e_68416655295c8324a2ef919924e490e9