### PR TITLE
Fix SearXNG banner

### DIFF
--- a/scripts/06_final_report.sh
+++ b/scripts/06_final_report.sh
@@ -143,7 +143,7 @@ fi
 
 if is_profile_active "searxng"; then
   echo
-  echo "================================= Searxng ============================="
+  echo "================================= SearXNG ============================="
   echo
   echo "Host: ${SEARXNG_HOSTNAME:-<hostname_not_set>}"
   echo "User: ${SEARXNG_USERNAME:-<not_set_in_env>}"


### PR DESCRIPTION
## Summary
- correct service name `SearXNG` in final report

## Testing
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841664ba854832488715f4469446b69