### PR TITLE
Fix n8n_pipe message list initialization

### DIFF
--- a/n8n_pipe.py
+++ b/n8n_pipe.py
@@ -108,6 +108,7 @@ class Pipe:
                     raise Exception(f"Error: {response.status_code} - {response.text}")
 
                 # Set assistant message with chain reply
+                body.setdefault("messages", [])
                 body["messages"].append({"role": "assistant", "content": n8n_response})
             except Exception as e:
                 await self.emit_status(


### PR DESCRIPTION
## Summary
- ensure the messages list exists before appending in `Pipe.pipe`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684172f1d7b083249dbf953088071cb0