### PR TITLE
Fix tests by adding requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,9 +299,10 @@ The installer creates a `shared` folder (by default, located in the same directo
 
 ## Running Tests
 
-Unit tests reside in the `tests` folder. After installing `pytest`, run the suite from the project root:
+Unit tests reside in the `tests` folder. Install test dependencies using `pip` and run the suite from the project root:
 
 ```bash
+pip install -r requirements.txt
 python -m pytest
 ```
 

--- a/n8n_pipe.py
+++ b/n8n_pipe.py
@@ -9,7 +9,6 @@ This module defines a Pipe class that utilizes N8N for an Agent
 
 from typing import Optional, Callable, Awaitable
 from pydantic import BaseModel, Field
-import os
 import time
 import requests
 
@@ -44,7 +43,6 @@ class Pipe:
         self.name = "N8N Pipe"
         self.valves = self.Valves()
         self.last_emit_time = 0
-        pass
 
     async def emit_status(
         self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.30,<3
+pytest
+pytest-asyncio


### PR DESCRIPTION
## Summary
- remove unused import and `pass`
- document running tests with `requirements.txt`
- add `requirements.txt` for tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684176ce70c08324bf0fb32b881b8329